### PR TITLE
Update peering acceptor role to do transit gateway attachment and route acceptance

### DIFF
--- a/modules/cloudaccess/wf_peering_acceptor_policy.json
+++ b/modules/cloudaccess/wf_peering_acceptor_policy.json
@@ -18,7 +18,18 @@
                 "ec2:ModifyVpcAttribute",
                 "ec2:DescribeRouteTables",
                 "ec2:CreateRoute",
-                "ec2:DeleteRoute"
+                "ec2:DeleteRoute",
+                "ec2:AcceptTransitGatewayVpcAttachment",
+                "ec2:CreateTransitGatewayVpcAttachment",
+                "ec2:DescribeTransitGatewayAttachments",
+                "ec2:DisassociateTransitGatewayRouteTables",
+                "ec2:DescribeTransitGatewayRouteTables",
+                "ec2:GetTransitGatewayRouteTablePropagations",
+                "ec2:DisableTransitGatewayRouteTablePropagation",
+                "ec2:EnableTransitGatewayRouteTablePropagation",
+                "ec2:AssociateTransitGatewayRouteTable",
+                "ec2:DeleteTransitGatewayVpcAttachment",
+                "ec2:DescribeTransitGateways"
             ],
             "Effect": "Allow",
             "Resource": "*"


### PR DESCRIPTION
This will be required in v2.4.4 when we add support for the peering acceptor role into Wayfinder with Transit Gateway acceptance support.