### PR TITLE
Updates for v2.6 - Add describe VPCs to DNS zone manager for private Route53 zones

### DIFF
--- a/modules/cloudaccess/wf_dns_zone_manager_policy.json
+++ b/modules/cloudaccess/wf_dns_zone_manager_policy.json
@@ -17,7 +17,8 @@
                 "route53:GetHostedZone",
                 "route53:ListHostedZones",
                 "route53:ListResourceRecordSets",
-                "route53:ListTagsForResource"
+                "route53:ListTagsForResource",
+                "ec2:DescribeVpcs"
             ],
             "Effect": "Allow",
             "Resource": "*"
@@ -38,6 +39,13 @@
                 "iam:TagRole",
                 "iam:UpdateAssumeRolePolicy",
                 "iam:UpdateRoleDescription"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        },
+        {
+            "Action": [
+                "ec2:DescribeVpcs"
             ],
             "Effect": "Allow",
             "Resource": "*"

--- a/modules/cloudaccess/wf_dns_zone_manager_policy.json
+++ b/modules/cloudaccess/wf_dns_zone_manager_policy.json
@@ -17,8 +17,7 @@
                 "route53:GetHostedZone",
                 "route53:ListHostedZones",
                 "route53:ListResourceRecordSets",
-                "route53:ListTagsForResource",
-                "ec2:DescribeVpcs"
+                "route53:ListTagsForResource"
             ],
             "Effect": "Allow",
             "Resource": "*"


### PR DESCRIPTION
At the moment this is the only permission update needed for private DNS for v2.6, but will test / validate this and update with any further permissions identified.